### PR TITLE
Change Delay.h include to relative path

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -48,8 +48,8 @@
 //Locate Delay.h file in your local Marlin copy: Marlin 2.0/Marlin/Marlin/src/HAL/shared/Delay.h
 //and enter full path to this file below
 
-#include "C:\Users\Fernando\Documents\GitHub\Marlin\Marlin\src\HAL\shared\Delay.h"
-
+//#include "C:\Users\Fernando\Documents\GitHub\Marlin\Marlin\src\HAL\shared\Delay.h"
+#include "../../../../../Marlin/Marlin/src/HAL/shared/Delay.h"
 
 #ifdef TARGET_LPC1768
   #include <time.h>

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -45,11 +45,7 @@
 
 #include "Adafruit_NeoPixel.h"
 
-//Locate Delay.h file in your local Marlin copy: Marlin 2.0/Marlin/Marlin/src/HAL/shared/Delay.h
-//and enter full path to this file below
-
-//#include "C:\Users\Fernando\Documents\GitHub\Marlin\Marlin\src\HAL\shared\Delay.h"
-#include "../../../../../Marlin/Marlin/src/HAL/shared/Delay.h"
+#include "../../../../Marlin/src/HAL/shared/Delay.h"
 
 #ifdef TARGET_LPC1768
   #include <time.h>

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -48,7 +48,7 @@
 //Locate Delay.h file in your local Marlin copy: Marlin 2.0/Marlin/Marlin/src/HAL/shared/Delay.h
 //and enter full path to this file below
 
-#include <replace with path to Delay.h file>
+#include "C:\Users\Fernando\Documents\GitHub\Marlin\Marlin\src\HAL\shared\Delay.h"
 
 
 #ifdef TARGET_LPC1768


### PR DESCRIPTION
Have changed the include for Delay.h to use a relative path which makes compiling across different platforms/systems easier.

I can cnly test on VScode under Windows, but the recommended path was given to me here https://github.com/MarlinFirmware/Marlin/pull/18833#issuecomment-667617734 and they use VScode under Linux.